### PR TITLE
convert webhooks.event_filter `None`, `{}` to `[]`

### DIFF
--- a/ex_app/lib/main.py
+++ b/ex_app/lib/main.py
@@ -370,11 +370,13 @@ def _webhooks_syncing():
         registered_listeners = get_registered_listeners()
         print("get_registered_listeners: ", json.dumps(registered_listeners, indent=4), flush=True)
         for expected_listener in expected_listeners:
+            expected_listener["filters"] = _preprocess_webhook_event_filter(expected_listener["filters"])
             registered_listeners_for_uri = get_registered_listeners_for_uri(
                 expected_listener["webhook"], registered_listeners
             )
             for event in expected_listener["events"]:
                 listener = next(filter(lambda listener: listener["event"] == event, registered_listeners_for_uri), None)
+                listener["eventFilter"] = _preprocess_webhook_event_filter(listener["eventFilter"])
                 if listener is not None:
                     if listener["eventFilter"] != expected_listener["filters"]:
                         print("webhooks_syncing: before update_listener:", json.dumps(listener))
@@ -396,6 +398,12 @@ def _webhooks_syncing():
                 ):
                     delete_listener(registered_listener)
         sleep(30)
+
+
+def _preprocess_webhook_event_filter(event_filter):
+    if event_filter in (None, {}):
+        return []
+    return event_filter
 
 
 def get_flow_paths(workspace: str, token: str) -> list[str]:


### PR DESCRIPTION
without this webhooks got constantly updated:

```
webhooks_syncing(expected_listeners):
 [
    {
        "webhook": "/api/w/nextcloud/jobs/run/f/u/wapp_jos/file_creation",
        "filters": {},
        "events": [
            "OCP\\Files\\Events\\Node\\NodeWrittenEvent"
        ]
    }
]
get_registered_listeners:  [
    {
        "id": 1,
        "appId": "windmill_app",
        "userId": null,
        "httpMethod": "POST",
        "uri": "/api/w/nextcloud/jobs/run/f/u/wapp_jos/file_creation",
        "event": "OCP\\Files\\Events\\Node\\NodeWrittenEvent",
        "eventFilter": null,
        "userIdFilter": "",
        "headers": null,
        "authMethod": "header",
        "authData": "EDITED"
    }
]
webhooks_syncing: before update_listener: {"id": 1, "appId": "windmill_app", "userId": null, "httpMethod": "POST", "uri": "/api/w/nextcloud/jobs/run/f/u/wapp_jos/file_creation", "event": "OCP\\Files\\Events\\Node\\NodeWrittenEvent", "eventFilter": null, "userIdFilter": "", "headers": null, "authMethod": "header", "authData": "EDITED"}
update_listener: /api/w/nextcloud/jobs/run/f/u/wapp_jos/file_creation - OCP\Files\Events\Node\NodeWrittenEvent
{}
update_listener:
 {
    "id": 1,
    "appId": "windmill_app",
    "userId": null,
    "httpMethod": "POST",
    "uri": "/api/w/nextcloud/jobs/run/f/u/wapp_jos/file_creation",
    "event": "OCP\\Files\\Events\\Node\\NodeWrittenEvent",
    "eventFilter": [],
    "userIdFilter": "",
    "headers": null,
    "authMethod": "header",
    "authData":"EDITED"
}
/api/w/nextcloud/jobs/list
```

My suggestion is to just convert when value is empty always it to format of `[]`